### PR TITLE
feat: Add audio to GlEink config.

### DIFF
--- a/lib/config/v2/gl_eink.ex
+++ b/lib/config/v2/gl_eink.ex
@@ -2,7 +2,7 @@ defmodule ScreensConfig.V2.GlEink do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias ScreensConfig.V2.{Alerts, Departures, EvergreenContentItem, Footer, LineMap}
+  alias ScreensConfig.V2.{Alerts, Audio, Departures, EvergreenContentItem, Footer, LineMap}
   alias ScreensConfig.V2.Header.Destination
 
   @type t :: %__MODULE__{
@@ -11,7 +11,8 @@ defmodule ScreensConfig.V2.GlEink do
           header: Destination.t(),
           alerts: Alerts.t(),
           line_map: LineMap.t(),
-          evergreen_content: list(EvergreenContentItem.t())
+          evergreen_content: list(EvergreenContentItem.t()),
+          audio: Audio.t()
         }
 
   @enforce_keys [:departures, :footer, :header, :alerts, :line_map]
@@ -20,7 +21,8 @@ defmodule ScreensConfig.V2.GlEink do
             header: nil,
             alerts: nil,
             line_map: nil,
-            evergreen_content: []
+            evergreen_content: [],
+            audio: Audio.from_json(:default)
 
   use ScreensConfig.Struct,
     children: [
@@ -29,6 +31,7 @@ defmodule ScreensConfig.V2.GlEink do
       header: Destination,
       alerts: Alerts,
       line_map: LineMap,
-      evergreen_content: {:list, EvergreenContentItem}
+      evergreen_content: {:list, EvergreenContentItem},
+      audio: Audio
     ]
 end


### PR DESCRIPTION
When we switch to Mercury screens, we will have the ability to play audio on E-Ink. First thing needed to get it working is to allow the screen config to hold audio. 

[Notion task](https://app.asana.com/0/1176097567827729/1205748798471858/f)