### PR TITLE
tweak: Add new ReconstructedAlert widget config struct

### DIFF
--- a/lib/config/v2/pre_fare.ex
+++ b/lib/config/v2/pre_fare.ex
@@ -53,7 +53,7 @@ defmodule ScreensConfig.V2.PreFare do
       full_line_map: {:list, FullLineMap},
       evergreen_content: {:list, EvergreenContentItem},
       blue_bikes: BlueBikes,
-      reconstructed_alert_widget: CurrentStopId,
+      reconstructed_alert_widget: ReconstructedAlert,
       content_summary: ContentSummary,
       audio: Audio,
       cr_departures: CRDepartures,

--- a/lib/config/v2/pre_fare.ex
+++ b/lib/config/v2/pre_fare.ex
@@ -9,6 +9,7 @@ defmodule ScreensConfig.V2.PreFare do
     ElevatorStatus,
     EvergreenContentItem,
     FullLineMap,
+    ReconstructedAlert,
     ShuttleBusInfo
   }
 
@@ -16,7 +17,7 @@ defmodule ScreensConfig.V2.PreFare do
 
   @type t :: %__MODULE__{
           header: CurrentStopId.t(),
-          reconstructed_alert_widget: CurrentStopId.t(),
+          reconstructed_alert_widget: ReconstructedAlert.t(),
           elevator_status: ElevatorStatus.t(),
           full_line_map: list(FullLineMap.t()),
           evergreen_content: list(EvergreenContentItem.t()),

--- a/lib/config/v2/reconstructed_alert.ex
+++ b/lib/config/v2/reconstructed_alert.ex
@@ -1,0 +1,20 @@
+defmodule ScreensConfig.V2.ReconstructedAlert do
+  @moduledoc false
+
+  alias ScreensConfig.V2.Header.CurrentStopId
+
+  @type t :: %__MODULE__{
+          parent_station_id: CurrentStopId.t(),
+          pair_takeover_with_cr_widget: boolean()
+        }
+
+  @enforce_keys [:parent_station_id]
+  defstruct parent_station_id: nil,
+            pair_takeover_with_cr_widget: false
+
+  use ScreensConfig.Struct, children: [parent_station_id: CurrentStopId]
+
+  defp value_from_json(_, value), do: value
+
+  defp value_to_json(_, value), do: value
+end


### PR DESCRIPTION
This PR adds a new struct for the `ReconstructedAlert` widget config. The new struct will take the existing stop ID as well as a new boolean that tells the `WidgetInstance` to make any takeover alert single screen instead. We will eventually pair this with the CR widget so the single screen alert is on the left screen and the CR widget is on the right screen.