### PR TITLE
Rename `solari_v2` to `busway_v2`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 elixir 1.14.3-otp-25
-erlang 25.3.2
+erlang 25.3.2.9

--- a/lib/config/screen.ex
+++ b/lib/config/screen.ex
@@ -11,13 +11,13 @@ defmodule ScreensConfig.Screen do
           :bus_eink
           | :bus_eink_v2
           | :bus_shelter_v2
+          | :busway_v2
           | :dup
           | :dup_v2
           | :gl_eink_single
           | :gl_eink_double
           | :gl_eink_v2
           | :solari
-          | :solari_v2
           | :solari_large
           | :solari_large_v2
           | :pre_fare_v2
@@ -38,11 +38,11 @@ defmodule ScreensConfig.Screen do
             | Solari.t()
             | V2.BusEink.t()
             | V2.BusShelter.t()
-            | V2.GlEink.t()
-            | V2.Solari.t()
-            | V2.SolariLarge.t()
-            | V2.PreFare.t()
+            | V2.Busway.t()
             | V2.Dup.t()
+            | V2.GlEink.t()
+            | V2.PreFare.t()
+            | V2.SolariLarge.t()
             | V2.Triptych.t(),
           tags: list(String.t())
         }
@@ -51,7 +51,7 @@ defmodule ScreensConfig.Screen do
   @v2_app_id_suffix "_v2"
 
   @recognized_app_ids ~w[bus_eink dup gl_eink_single gl_eink_double solari solari_large]a
-  @recognized_v2_app_ids ~w[bus_eink_v2 bus_shelter_v2 dup_v2 gl_eink_v2 solari_v2 solari_large_v2 pre_fare_v2 triptych_v2]a
+  @recognized_v2_app_ids ~w[bus_eink_v2 bus_shelter_v2 busway_v2 dup_v2 gl_eink_v2 solari_large_v2 pre_fare_v2 triptych_v2]a
   @recognized_app_id_strings Enum.map(
                                @recognized_app_ids ++ @recognized_v2_app_ids,
                                &Atom.to_string/1
@@ -61,13 +61,13 @@ defmodule ScreensConfig.Screen do
     bus_eink: Bus,
     bus_eink_v2: V2.BusEink,
     bus_shelter_v2: V2.BusShelter,
+    busway_v2: V2.Busway,
     dup: Dup,
     dup_v2: V2.Dup,
     gl_eink_single: Gl,
     gl_eink_double: Gl,
     gl_eink_v2: V2.GlEink,
     solari: Solari,
-    solari_v2: V2.Solari,
     solari_large: Solari,
     solari_large_v2: V2.SolariLarge,
     pre_fare_v2: V2.PreFare,

--- a/lib/config/v2/busway.ex
+++ b/lib/config/v2/busway.ex
@@ -1,4 +1,4 @@
-defmodule ScreensConfig.V2.Solari do
+defmodule ScreensConfig.V2.Busway do
   @moduledoc false
 
   alias ScreensConfig.V2.Departures


### PR DESCRIPTION
Part of 📝 [Set up new app: backend stuff](https://app.asana.com/0/1185117109217413/1206730847640132)

This config was already here to support the `V2.Solari` "skeleton" that was set up in `screens` a few years back. For the initial setup it doesn't need any changes, but we know we want to call these "busway screens" now and renaming it earlier is probably better since nothing uses it yet.

Implications:

* **Screens:** I've already implemented an equivalent change there and will PR soon. If desired, we can hold off merging this until that PR is also approved.
* **Screenplay:** I can't find any references to `solari_v2` anywhere in Screenplay currently.