### PR TITLE
chore: Add explicit Jason dep

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule ScreensConfig.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:jason, "~> 1.0"},
       {:credo, "~> 1.6.0", only: [:dev, :test]},
       {:dialyxir, "~> 1.1.0", only: [:dev, :test], runtime: false}
     ]


### PR DESCRIPTION
Prevents compilation error due to at least one config module deriving `Jason.Encoder`.

Version requirement should work with both Screens (which requires Jason `~> 1.0`) and Screenplay (`~> 1.4`).