### PR TITLE
fix: missing `value_to_json` in `RouteDirections`

### DIFF
--- a/lib/config/v2/departures/filters/route_directions.ex
+++ b/lib/config/v2/departures/filters/route_directions.ex
@@ -24,4 +24,7 @@ defmodule ScreensConfig.V2.Departures.Filters.RouteDirections do
 
   defp value_from_json("action", "include"), do: :include
   defp value_from_json("action", "exclude"), do: :exclude
+
+  defp value_from_json(_, value), do: value
+  defp value_to_json(_, value), do: value
 end


### PR DESCRIPTION
These functions need to be explicitly defined for all keys that are not part of `children`.

This fixes encountering "An error occurred" when trying to change the config using the admin UI, if the config contains the new Sectional screens. Tested locally with a copy of the migrated Sectional config, and it now validates.