### PR TITLE
doc: correct descriptions of some section fields

### DIFF
--- a/lib/config/v2/departures/layout.ex
+++ b/lib/config/v2/departures/layout.ex
@@ -9,7 +9,7 @@ defmodule ScreensConfig.V2.Departures.Layout do
   `max` and `min` as hard limits.
 
   If `max` is not set, the section may grow to fill all available space. If `base` is not set, it
-  defaults to the value of `max`.
+  defaults to the value of `min`.
 
   If `include_later` is set, the section includes a paging "Later Departures" component, which
   shows departures that would have otherwise been dropped due to space constraints (plus as many

--- a/lib/config/v2/departures/section.ex
+++ b/lib/config/v2/departures/section.ex
@@ -3,9 +3,8 @@ defmodule ScreensConfig.V2.Departures.Section do
   Configures a section within the Departures widget. Sections are a means of grouping departures
   by mode, stopping location, etc. Each section can fetch and display its departures differently.
 
-  - `bidirectional` enables a special mode that displays exactly two departures: the first one
-    that would normally be displayed, and the next departure on the same route in the opposite
-    direction.
+  - `bidirectional` enables a filter which enforces a maximum of 2 departures: the first that
+    would normally be displayed, and the next one in the opposite direction, if there is one.
   """
 
   alias ScreensConfig.V2.Departures.{Filters, Header, Headway, Layout, Query}


### PR DESCRIPTION
These docs were written before the implementation was done on the `screens` side, and the actual behavior diverged slightly.