### PR TITLE
chore: Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mbta/digital-ride


### PR DESCRIPTION
Noticed another PR wasn't auto-assigning to @mbta/digital-ride and found this file was missing.