### PR TITLE
chore: Fix vendors

### DIFF
--- a/lib/config/screen.ex
+++ b/lib/config/screen.ex
@@ -123,7 +123,7 @@ defmodule ScreensConfig.Screen do
     |> String.ends_with?(@v2_app_id_suffix)
   end
 
-  defp value_from_json("vendor", vendor_string, _app_id) when vendor_string in ["n/a", ""],
+  defp value_from_json("vendor", vendor_string, _app_id) when vendor_string in ["n/a", "", nil],
     do: nil
 
   for vendor <- @recognized_vendors do

--- a/lib/config/screen.ex
+++ b/lib/config/screen.ex
@@ -23,7 +23,7 @@ defmodule ScreensConfig.Screen do
           | :pre_fare_v2
 
   @type t :: %__MODULE__{
-          vendor: :gds | :mercury | :solari | :c3ms | :outfront | :lg_mri | :mimo,
+          vendor: :gds | :mercury | :solari | :c3ms | :outfront | :lg_mri | :mimo | :n_a,
           device_id: String.t(),
           name: String.t(),
           app_id: app_id(),
@@ -122,12 +122,12 @@ defmodule ScreensConfig.Screen do
     |> String.ends_with?(@v2_app_id_suffix)
   end
 
-  for vendor <- ~w[gds mercury solari mimo c3ms outfront]a do
-    vendor_string = Atom.to_string(vendor)
+  defp value_from_json("vendor", "n/a", _app_id) do
+    :n_a
+  end
 
-    defp value_from_json("vendor", unquote(vendor_string), _app_id) do
-      unquote(vendor)
-    end
+  defp value_from_json("vendor", vendor_string, _app_id) do
+    String.to_existing_atom(vendor_string)
   end
 
   defp value_from_json("app_id", _app_id_string, app_id), do: app_id

--- a/lib/config/screen.ex
+++ b/lib/config/screen.ex
@@ -122,7 +122,7 @@ defmodule ScreensConfig.Screen do
     |> String.ends_with?(@v2_app_id_suffix)
   end
 
-  defp value_from_json("vendor", "n/a", _app_id) do
+  defp value_from_json("vendor", vendor_string, _app_id) when vendor_string in ["n/a", ""] do
     :n_a
   end
 

--- a/lib/config/screen.ex
+++ b/lib/config/screen.ex
@@ -23,7 +23,7 @@ defmodule ScreensConfig.Screen do
           | :pre_fare_v2
 
   @type t :: %__MODULE__{
-          vendor: :gds | :mercury | :solari | :c3ms | :outfront | :lg_mri | :mimo | :n_a,
+          vendor: :gds | :mercury | :solari | :c3ms | :outfront | :lg_mri | :mimo | nil,
           device_id: String.t(),
           name: String.t(),
           app_id: app_id(),
@@ -55,6 +55,7 @@ defmodule ScreensConfig.Screen do
                                @recognized_app_ids ++ @recognized_v2_app_ids,
                                &Atom.to_string/1
                              )
+  @recognized_vendors ~w[gds mercury solari c3ms outfront lg_mri mimo]a
 
   @app_config_modules_by_app_id %{
     bus_eink: Bus,
@@ -122,13 +123,19 @@ defmodule ScreensConfig.Screen do
     |> String.ends_with?(@v2_app_id_suffix)
   end
 
-  defp value_from_json("vendor", vendor_string, _app_id) when vendor_string in ["n/a", ""] do
-    :n_a
+  defp value_from_json("vendor", vendor_string, _app_id) when vendor_string in ["n/a", ""],
+    do: nil
+
+  for vendor <- @recognized_vendors do
+    vendor_string = Atom.to_string(vendor)
+
+    defp value_from_json("vendor", unquote(vendor_string), _app_id) do
+      unquote(vendor)
+    end
   end
 
-  defp value_from_json("vendor", vendor_string, _app_id) do
-    String.to_existing_atom(vendor_string)
-  end
+  defp value_from_json("vendor", unknown_vendor, _app_id),
+    do: raise("unknown vendor #{unknown_vendor}")
 
   defp value_from_json("app_id", _app_id_string, app_id), do: app_id
 


### PR DESCRIPTION
The list of vendors we converted to atoms and the list of allowed vendors were out of sync. I simplified the `from_json` logic so it just converts the vendor into an atom. Any existing vendors set to `n/a` or empty strings will map to `:n_a`. All other unknown vendors will fail and we can fix as needed. 