### PR TITLE
feat: simplify audio configuration

### DIFF
--- a/lib/config/v2/audio.ex
+++ b/lib/config/v2/audio.ex
@@ -2,45 +2,14 @@ defmodule ScreensConfig.V2.Audio do
   @moduledoc false
 
   @type t :: %__MODULE__{
-          start_time: Time.t(),
-          stop_time: Time.t(),
-          daytime_start_time: Time.t(),
-          daytime_stop_time: Time.t(),
-          days_active: list(Calendar.day_of_week()),
-          daytime_volume: float(),
-          nighttime_volume: float(),
+          interval_enabled: boolean(),
           interval_offset_seconds: non_neg_integer()
         }
 
-  defstruct start_time: ~T[00:00:00],
-            stop_time: ~T[00:00:00],
-            daytime_start_time: ~T[00:00:00],
-            daytime_stop_time: ~T[00:00:00],
-            days_active: [],
-            daytime_volume: 0.0,
-            nighttime_volume: 0.0,
-            interval_offset_seconds: 0
-
-  def always do
-    %__MODULE__{
-      start_time: ~T[00:00:00],
-      stop_time: ~T[23:59:59],
-      days_active: [1, 2, 3, 4, 5, 6, 7]
-    }
-  end
+  defstruct interval_enabled: false, interval_offset_seconds: 0
 
   use ScreensConfig.Struct, with_default: true
 
-  for time_key <- ~w[start_time stop_time daytime_start_time daytime_stop_time]a do
-    time_key_string = Atom.to_string(time_key)
-
-    defp value_from_json(unquote(time_key_string), iso_string) do
-      {:ok, t} = Time.from_iso8601(iso_string)
-      t
-    end
-  end
-
   defp value_from_json(_, value), do: value
-
   defp value_to_json(_, value), do: value
 end

--- a/lib/config/v2/busway.ex
+++ b/lib/config/v2/busway.ex
@@ -11,25 +11,20 @@ defmodule ScreensConfig.V2.Busway do
   typically split into multiple sections.
   """
 
-  alias ScreensConfig.V2.{Audio, Departures, EvergreenContentItem}
+  alias ScreensConfig.V2.{Departures, EvergreenContentItem}
   alias ScreensConfig.V2.Header.CurrentStopName
 
   @type t :: %__MODULE__{
-          audio: Audio.t(),
           departures: Departures.t(),
           evergreen_content: list(EvergreenContentItem.t()),
           header: CurrentStopName.t()
         }
 
   @enforce_keys [:departures, :header]
-  defstruct audio: Audio.always(),
-            departures: nil,
-            evergreen_content: [],
-            header: nil
+  defstruct departures: nil, evergreen_content: [], header: nil
 
   use ScreensConfig.Struct,
     children: [
-      audio: Audio,
       departures: Departures,
       evergreen_content: {:list, EvergreenContentItem},
       header: CurrentStopName

--- a/lib/config/v2/gl_eink.ex
+++ b/lib/config/v2/gl_eink.ex
@@ -2,7 +2,7 @@ defmodule ScreensConfig.V2.GlEink do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias ScreensConfig.V2.{Alerts, Audio, Departures, EvergreenContentItem, Footer, LineMap}
+  alias ScreensConfig.V2.{Alerts, Departures, EvergreenContentItem, Footer, LineMap}
   alias ScreensConfig.V2.Header.Destination
 
   @type t :: %__MODULE__{
@@ -12,7 +12,6 @@ defmodule ScreensConfig.V2.GlEink do
           alerts: Alerts.t(),
           line_map: LineMap.t(),
           evergreen_content: list(EvergreenContentItem.t()),
-          audio: Audio.t(),
           platform_location: :front | :back | nil
         }
 
@@ -23,7 +22,6 @@ defmodule ScreensConfig.V2.GlEink do
             alerts: nil,
             line_map: nil,
             evergreen_content: [],
-            audio: Audio.always(),
             platform_location: nil
 
   use ScreensConfig.Struct,
@@ -33,8 +31,7 @@ defmodule ScreensConfig.V2.GlEink do
       header: Destination,
       alerts: Alerts,
       line_map: LineMap,
-      evergreen_content: {:list, EvergreenContentItem},
-      audio: Audio
+      evergreen_content: {:list, EvergreenContentItem}
     ]
 
   defp value_from_json("platform_location", location) do

--- a/lib/config/v2/pre_fare.ex
+++ b/lib/config/v2/pre_fare.ex
@@ -2,7 +2,6 @@ defmodule ScreensConfig.V2.PreFare do
   @moduledoc false
 
   alias ScreensConfig.V2.{
-    Audio,
     BlueBikes,
     ContentSummary,
     CRDepartures,
@@ -22,7 +21,6 @@ defmodule ScreensConfig.V2.PreFare do
           evergreen_content: list(EvergreenContentItem.t()),
           blue_bikes: BlueBikes.t(),
           content_summary: ContentSummary.t(),
-          audio: Audio.t(),
           cr_departures: CRDepartures.t(),
           shuttle_bus_info: ShuttleBusInfo.t()
         }
@@ -41,7 +39,6 @@ defmodule ScreensConfig.V2.PreFare do
             evergreen_content: [],
             blue_bikes: BlueBikes.from_json(:default),
             content_summary: nil,
-            audio: Audio.always(),
             cr_departures: CRDepartures.from_json(:default),
             shuttle_bus_info: ShuttleBusInfo.from_json(:default)
 
@@ -54,7 +51,6 @@ defmodule ScreensConfig.V2.PreFare do
       blue_bikes: BlueBikes,
       reconstructed_alert_widget: CurrentStopId,
       content_summary: ContentSummary,
-      audio: Audio,
       cr_departures: CRDepartures,
       shuttle_bus_info: ShuttleBusInfo
     ]


### PR DESCRIPTION
All audio config values (except the periodic readout offset for bus shelters) are currently identical across all screens of a given type, and we expect/want this to continue to be true. We can simplify by making these un-configurable and essentially embedding the config for each screen type in Screens, as is currently done for e.g. the readout interval.

This also adds one field, indicating whether to enable periodic audio readouts. We expect to need this for upcoming bus shelter screens that will have audio buttons.