### PR TITLE
update: Elevator config

### DIFF
--- a/lib/config/v2/elevator.ex
+++ b/lib/config/v2/elevator.ex
@@ -9,16 +9,21 @@ defmodule ScreensConfig.V2.Elevator do
           evergreen_content: list(EvergreenContentItem.t()),
           alternate_direction_text: String.t(),
           accessible_path_image_url: String.t(),
-          accessible_path_direction_arrow: Arrow.t()
+          accessible_path_direction_arrow: Arrow.t(),
+          you_are_here_coordinates: %{x: non_neg_integer(), y: non_neg_integer()}
         }
 
   @enforce_keys [
     :elevator_id,
     :alternate_direction_text,
-    :accessible_path_image_url,
     :accessible_path_direction_arrow
   ]
-  defstruct @enforce_keys ++ [evergreen_content: []]
+  defstruct @enforce_keys ++
+              [
+                evergreen_content: [],
+                accessible_path_image_url: nil,
+                you_are_here_coordinates: %{x: 0, y: 0}
+              ]
 
   use ScreensConfig.Struct,
     children: [

--- a/lib/config/v2/elevator.ex
+++ b/lib/config/v2/elevator.ex
@@ -8,9 +8,9 @@ defmodule ScreensConfig.V2.Elevator do
           elevator_id: String.t(),
           evergreen_content: list(EvergreenContentItem.t()),
           alternate_direction_text: String.t(),
-          accessible_path_image_url: String.t(),
+          accessible_path_image_url: String.t() | nil,
           accessible_path_direction_arrow: Arrow.t(),
-          you_are_here_coordinates: %{x: non_neg_integer(), y: non_neg_integer()}
+          accessible_path_image_here_coordinates: %{x: non_neg_integer(), y: non_neg_integer()}
         }
 
   @enforce_keys [
@@ -22,7 +22,7 @@ defmodule ScreensConfig.V2.Elevator do
               [
                 evergreen_content: [],
                 accessible_path_image_url: nil,
-                you_are_here_coordinates: %{x: 0, y: 0}
+                accessible_path_image_here_coordinates: %{x: 0, y: 0}
               ]
 
   use ScreensConfig.Struct,


### PR DESCRIPTION
There was one thing I missed in the design and another that was changed. 
- Screens will not be required to have accessible path images. If the image is `nil`, we will limit the layout to one page.
- There is a pulsating marker on the maps to indicate where the rider is currently located. My idea is this component will be positioned absolutely and we can configure the coordinates it should be displayed at. Essentially, `x` maps to `top` and `y` maps to `left`.