### PR TITLE
ci: update Action versions

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,16 +8,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       # cache the ASDF directory, using the values from .tool-versions
       - name: ASDF cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
+          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       # only run `asdf install` if we didn't hit the cache
-      - uses: asdf-vm/actions/install@v1
+      - uses: asdf-vm/actions/install@v3
         if: steps.asdf-cache.outputs.cache-hit != 'true'
 
   build:
@@ -26,10 +26,10 @@ jobs:
     needs: asdf
     steps:
       - name: ASDF cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.asdf
-          key: ${{ runner.os }}-asdf-v2-${{ hashFiles('.tool-versions') }}
+          key: ${{ runner.os }}-asdf-${{ hashFiles('.tool-versions') }}
         id: asdf-cache
       - name: Setup ASDF environment
         run: |
@@ -39,10 +39,10 @@ jobs:
           echo "$ASDF_DIR/bin" >> $GITHUB_PATH
           echo "$ASDF_DIR/shims" >> $GITHUB_PATH
           $ASDF_DIR/bin/asdf reshim
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Restore dependencies cache
         id: deps-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -60,4 +60,4 @@ jobs:
         run: mix credo --strict
       - name: Run tests
         run: mix test
-      - uses: mbta/actions/dialyzer@v1
+      - uses: mbta/actions/dialyzer@v2


### PR DESCRIPTION
Prompted by CI [currently failing](https://github.com/mbta/screens-config-lib/actions/runs/13639401980) because it uses a deprecated version of `actions/cache`.

Also removes a `-v2` cache prefix that had no purpose; this was there since the beginning of the repo and there was never a "v1".