### PR TITLE
[feat] Config option for Wayfinding only departures section

### DIFF
--- a/lib/config/departures/header.ex
+++ b/lib/config/departures/header.ex
@@ -7,6 +7,8 @@ defmodule ScreensConfig.Departures.Header do
     compass directions where "n" is towards the top of the display.
   - `read_as` is how the section should be announced in audio readouts. If `nil`, defaults to the
     configured `title`.
+  - `wayfinding_text` is a String that sets a subheading, intended for wayfinding directions. If `nil`,
+    defaults to not including the subheading
 
   If `title` is not set, there is no visual header, but `read_as` is still read out, if set.
   """
@@ -16,10 +18,11 @@ defmodule ScreensConfig.Departures.Header do
   @type t :: %__MODULE__{
           arrow: Arrow.t(),
           read_as: String.t() | nil,
-          title: String.t() | nil
+          title: String.t() | nil,
+          wayfinding_text: String.t() | nil
         }
 
-  defstruct [:arrow, :read_as, :title]
+  defstruct [:arrow, :read_as, :title, :wayfinding_text]
 
   use ScreensConfig.Struct, with_default: true
 

--- a/lib/config/departures/header.ex
+++ b/lib/config/departures/header.ex
@@ -18,11 +18,11 @@ defmodule ScreensConfig.Departures.Header do
   @type t :: %__MODULE__{
           arrow: Arrow.t(),
           read_as: String.t() | nil,
-          title: String.t() | nil,
-          subtitle: String.t() | nil
+          subtitle: String.t() | nil,
+          title: String.t() | nil
         }
 
-  defstruct [:arrow, :read_as, :title, :subtitle]
+  defstruct [:arrow, :read_as, :subtitle, :title]
 
   use ScreensConfig.Struct, with_default: true
 

--- a/lib/config/departures/header.ex
+++ b/lib/config/departures/header.ex
@@ -7,8 +7,8 @@ defmodule ScreensConfig.Departures.Header do
     compass directions where "n" is towards the top of the display.
   - `read_as` is how the section should be announced in audio readouts. If `nil`, defaults to the
     configured `title`.
-  - `wayfinding_text` is a String that sets a subheading, intended for wayfinding directions. If `nil`,
-    defaults to not including the subheading
+  - `subtitle` is a String that sets a subheading, initially intended for wayfinding directions,
+    but usable for other types of subheadings. If `nil`, defaults to not including the subheading.
 
   If `title` is not set, there is no visual header, but `read_as` is still read out, if set.
   """
@@ -19,10 +19,10 @@ defmodule ScreensConfig.Departures.Header do
           arrow: Arrow.t(),
           read_as: String.t() | nil,
           title: String.t() | nil,
-          wayfinding_text: String.t() | nil
+          subtitle: String.t() | nil
         }
 
-  defstruct [:arrow, :read_as, :title, :wayfinding_text]
+  defstruct [:arrow, :read_as, :title, :subtitle]
 
   use ScreensConfig.Struct, with_default: true
 

--- a/lib/config/departures/section.ex
+++ b/lib/config/departures/section.ex
@@ -5,8 +5,8 @@ defmodule ScreensConfig.Departures.Section do
 
   - `bidirectional` enables a filter which enforces a maximum of 2 departures: the first that
     would normally be displayed, and the next one in the opposite direction, if there is one.
-  - `wayfinding_only_text`disables fetching of departures so that only wayfinding directions,
-    passed in through this parameter, are displayed
+  - `wayfinding_only, when true, disables fetching of departures so that only wayfinding directions,
+    passed in through the header, are shown. Defaults to false.
   """
 
   alias ScreensConfig.Departures.{Filters, Header, Layout, Query}
@@ -17,7 +17,7 @@ defmodule ScreensConfig.Departures.Section do
           header: Header.t(),
           layout: Layout.t(),
           bidirectional: boolean(),
-          wayfinding_only_text: String.t() | nil
+          wayfinding_only: boolean()
         }
 
   @enforce_keys [:query]
@@ -26,7 +26,7 @@ defmodule ScreensConfig.Departures.Section do
             header: Header.from_json(:default),
             layout: Layout.from_json(:default),
             bidirectional: false,
-            wayfinding_only_text: nil
+            wayfinding_only: false
 
   use ScreensConfig.Struct,
     children: [query: Query, header: Header, filters: Filters, layout: Layout]

--- a/lib/config/departures/section.ex
+++ b/lib/config/departures/section.ex
@@ -5,6 +5,8 @@ defmodule ScreensConfig.Departures.Section do
 
   - `bidirectional` enables a filter which enforces a maximum of 2 departures: the first that
     would normally be displayed, and the next one in the opposite direction, if there is one.
+  - `wayfinding_only`disables fetching of departures so that only wayfinding directions, configured
+    in the header, but no upcoming departures, are displayed
   """
 
   alias ScreensConfig.Departures.{Filters, Header, Layout, Query}
@@ -14,7 +16,8 @@ defmodule ScreensConfig.Departures.Section do
           filters: Filters.t(),
           header: Header.t(),
           layout: Layout.t(),
-          bidirectional: boolean()
+          bidirectional: boolean(),
+          wayfinding_only: boolean()
         }
 
   @enforce_keys [:query]
@@ -22,7 +25,8 @@ defmodule ScreensConfig.Departures.Section do
             filters: Filters.from_json(:default),
             header: Header.from_json(:default),
             layout: Layout.from_json(:default),
-            bidirectional: false
+            bidirectional: false,
+            wayfinding_only: false
 
   use ScreensConfig.Struct,
     children: [query: Query, header: Header, filters: Filters, layout: Layout]

--- a/lib/config/departures/section.ex
+++ b/lib/config/departures/section.ex
@@ -5,8 +5,8 @@ defmodule ScreensConfig.Departures.Section do
 
   - `bidirectional` enables a filter which enforces a maximum of 2 departures: the first that
     would normally be displayed, and the next one in the opposite direction, if there is one.
-  - `wayfinding_only, when true, disables fetching of departures so that only wayfinding directions,
-    passed in through the header, are shown. Defaults to false.
+  - `header_only, when true, disables fetching of departures so that only the header + subheader
+    of the section are shown. Defaults to false.
   """
 
   alias ScreensConfig.Departures.{Filters, Header, Layout, Query}
@@ -17,7 +17,7 @@ defmodule ScreensConfig.Departures.Section do
           header: Header.t(),
           layout: Layout.t(),
           bidirectional: boolean(),
-          wayfinding_only: boolean()
+          header_only: boolean()
         }
 
   @enforce_keys [:query]
@@ -26,7 +26,7 @@ defmodule ScreensConfig.Departures.Section do
             header: Header.from_json(:default),
             layout: Layout.from_json(:default),
             bidirectional: false,
-            wayfinding_only: false
+            header_only: false
 
   use ScreensConfig.Struct,
     children: [query: Query, header: Header, filters: Filters, layout: Layout]

--- a/lib/config/departures/section.ex
+++ b/lib/config/departures/section.ex
@@ -5,8 +5,8 @@ defmodule ScreensConfig.Departures.Section do
 
   - `bidirectional` enables a filter which enforces a maximum of 2 departures: the first that
     would normally be displayed, and the next one in the opposite direction, if there is one.
-  - `wayfinding_only`disables fetching of departures so that only wayfinding directions, configured
-    in the header, but no upcoming departures, are displayed
+  - `wayfinding_only_text`disables fetching of departures so that only wayfinding directions,
+    passed in through this parameter, are displayed
   """
 
   alias ScreensConfig.Departures.{Filters, Header, Layout, Query}
@@ -17,7 +17,7 @@ defmodule ScreensConfig.Departures.Section do
           header: Header.t(),
           layout: Layout.t(),
           bidirectional: boolean(),
-          wayfinding_only: boolean()
+          wayfinding_only_text: String.t() | nil
         }
 
   @enforce_keys [:query]
@@ -26,7 +26,7 @@ defmodule ScreensConfig.Departures.Section do
             header: Header.from_json(:default),
             layout: Layout.from_json(:default),
             bidirectional: false,
-            wayfinding_only: false
+            wayfinding_only_text: nil
 
   use ScreensConfig.Struct,
     children: [query: Query, header: Header, filters: Filters, layout: Layout]


### PR DESCRIPTION
Adds two configuration options for wayfinding directions to be used in prefares.
- Boolean field that will disable departures fetching, included in a section's configuration
- Text field, passed in through the header, that will be used to show the wayfinding directions. This can be used regardless of the boolean field