### PR TITLE
chore: footer `stop_id` can be null

### DIFF
--- a/lib/config/footer.ex
+++ b/lib/config/footer.ex
@@ -1,13 +1,12 @@
 defmodule ScreensConfig.Footer do
   @moduledoc false
 
-  @type t :: %__MODULE__{stop_id: String.t()}
+  @type t :: %__MODULE__{stop_id: String.t() | nil}
 
   defstruct stop_id: nil
 
   use ScreensConfig.Struct
 
   defp value_from_json(_, value), do: value
-
   defp value_to_json(_, value), do: value
 end


### PR DESCRIPTION
This field could already be `nil` in practice given that is the default value, and we intend that this should be possible (e.g. to configure a footer on a screen not associated with a single stop), so document that in the typespec.