### PR TITLE
feat: JSON format migration in `Struct`

### DIFF
--- a/test/config/struct_test.exs
+++ b/test/config/struct_test.exs
@@ -112,6 +112,21 @@ defmodule TEST.Config9 do
   defp value_to_json(:a, value), do: value
 end
 
+defmodule TEST.Migration do
+  @type t :: %__MODULE__{b: String.t(), c: :one | :two}
+
+  defstruct b: "", c: ""
+
+  use ScreensConfig.Struct
+
+  defp migrate_json(%{"a" => value}), do: %{"b" => value, "c" => "one"}
+
+  defp value_from_json("c", "one"), do: :one
+  defp value_from_json("c", "two"), do: :two
+  defp value_from_json(_, value), do: value
+  defp value_to_json(_, value), do: value
+end
+
 defmodule ScreensConfig.StructTest do
   use ExUnit.Case, async: true
 
@@ -206,6 +221,10 @@ defmodule ScreensConfig.StructTest do
       original_json2 = %{"a" => "foo", "b" => true}
 
       assert_raise FunctionClauseError, fn -> Config9.from_json(original_json2) end
+    end
+
+    test "allows loading a previous JSON format when migrate_json/2 is defined" do
+      assert TEST.Migration.from_json(%{"a" => "test"}) == %TEST.Migration{b: "test", c: :one}
     end
   end
 end


### PR DESCRIPTION
Adds the option for modules using `ScreensConfig.Struct` to define a `migrate_json/1` function which can transform the JSON before it is fully deserialized. The short-term motivation is to enable conveniently renaming the `stop_id` field in `ScreensConfig.Alerts` to `stop_ids`, since we would like to support multiple stop IDs here and the name should reflect that. But this provides a generic capability to do many kinds of backwards-incompatible JSON format "migration".