### PR TITLE
feat: support multiple stop IDs in alerts config

### DIFF
--- a/lib/config/multi_stop_alerts.ex
+++ b/lib/config/multi_stop_alerts.ex
@@ -1,0 +1,18 @@
+defmodule ScreensConfig.MultiStopAlerts do
+  @moduledoc "Configuration for screens that can show alerts for multiple stops."
+
+  @type t :: %__MODULE__{stop_ids: [String.t()]}
+
+  defstruct stop_ids: []
+
+  use ScreensConfig.Struct
+
+  # Allow migrating from `ScreensConfig.Alerts` which has a singular `stop_id`.
+  defp migrate_json(%{"stop_id" => stop_id} = json) when not is_nil(stop_id),
+    do: Map.put(json, "stop_ids", [stop_id])
+
+  defp migrate_json(other), do: other
+
+  defp value_from_json(_, value), do: value
+  defp value_to_json(_, value), do: value
+end

--- a/lib/config/screen/bus_eink.ex
+++ b/lib/config/screen/bus_eink.ex
@@ -2,13 +2,13 @@ defmodule ScreensConfig.Screen.BusEink do
   @moduledoc false
   # credo:disable-for-this-file Credo.Check.Design.DuplicatedCode
 
-  alias ScreensConfig.{Alerts, Departures, EvergreenContentItem, Footer, Header}
+  alias ScreensConfig.{Departures, EvergreenContentItem, Footer, Header, MultiStopAlerts}
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
           footer: Footer.t(),
           header: Header.t(),
-          alerts: Alerts.t(),
+          alerts: MultiStopAlerts.t(),
           evergreen_content: list(EvergreenContentItem.t())
         }
 
@@ -23,7 +23,7 @@ defmodule ScreensConfig.Screen.BusEink do
     children: [
       departures: Departures,
       footer: Footer,
-      alerts: Alerts,
+      alerts: MultiStopAlerts,
       evergreen_content: {:list, EvergreenContentItem}
     ]
 


### PR DESCRIPTION
See #61 for the implementation of `migrate_json/1`, which this depends on.