### PR TITLE
fix: already-existing-atom error with Arrows

### DIFF
--- a/lib/config/arrow.ex
+++ b/lib/config/arrow.ex
@@ -4,4 +4,11 @@ defmodule ScreensConfig.Arrow do
   """
 
   @type t :: :n | :ne | :e | :se | :s | :sw | :w | :nw | :uturn | nil
+
+  @spec from_json(String.t() | nil) :: t()
+  for atom <- ~w(n ne e se s sw w nw uturn)a do
+    def from_json(unquote(to_string(atom))), do: unquote(atom)
+  end
+
+  def from_json(value) when value in [nil, ""], do: nil
 end

--- a/lib/config/departures/header.ex
+++ b/lib/config/departures/header.ex
@@ -26,9 +26,7 @@ defmodule ScreensConfig.Departures.Header do
 
   use ScreensConfig.Struct, with_default: true
 
-  defp value_from_json("arrow", value) when value in ~w(n ne e se s sw w nw),
-    do: String.to_existing_atom(value)
-
+  defp value_from_json("arrow", value), do: Arrow.from_json(value)
   defp value_from_json(_, value), do: value
   defp value_to_json(_, value), do: value
 end

--- a/lib/config/screen/elevator.ex
+++ b/lib/config/screen/elevator.ex
@@ -30,7 +30,7 @@ defmodule ScreensConfig.Screen.Elevator do
       evergreen_content: {:list, EvergreenContentItem}
     ]
 
+  defp value_from_json("accessible_path_direction_arrow", value), do: Arrow.from_json(value)
   defp value_from_json(_, value), do: value
-
   defp value_to_json(_, value), do: value
 end


### PR DESCRIPTION
Atoms that exist only in typespecs are not always considered to "exist" at runtime; as a result, deserializing an `Arrow` would sometimes crash. Refactor this so the atoms do "exist" and the two places that use Arrows have a shared logic to deserialize them.