### PR TITLE
Added field for including logo in header for Busway 

### DIFF
--- a/lib/config/screen/busway.ex
+++ b/lib/config/screen/busway.ex
@@ -17,11 +17,12 @@ defmodule ScreensConfig.Screen.Busway do
   @type t :: %__MODULE__{
           departures: Departures.t(),
           evergreen_content: list(EvergreenContentItem.t()),
-          header: Header.t()
+          header: Header.t(),
+          include_logo_in_header: boolean()
         }
 
   @enforce_keys [:departures, :header]
-  defstruct departures: nil, evergreen_content: [], header: nil
+  defstruct departures: nil, evergreen_content: [], header: nil, include_logo_in_header: false
 
   use ScreensConfig.Struct,
     children: [
@@ -30,4 +31,7 @@ defmodule ScreensConfig.Screen.Busway do
     ]
 
   use Header
+
+  defp value_from_json(_, value), do: value
+  defp value_to_json(_, value), do: value
 end


### PR DESCRIPTION
- Added `include_logo_in_header` to show/hide logo
- Currently defaults to false, always hiding unless configured to for third-party screens