### PR TITLE
Add ferry and capeflyer to FreeText route pill types

### DIFF
--- a/lib/config/free_text/free_text.ex
+++ b/lib/config/free_text/free_text.ex
@@ -23,7 +23,9 @@ defmodule ScreensConfig.FreeText do
           | :green_c
           | :green_d
           | :green_e
-  @type color :: :red | :blue | :orange | :green | :silver | :purple
+          | :capeflyer
+          | :ferry
+  @type color :: :red | :blue | :orange | :green | :silver | :purple | :teal | :ocean_blue
   @type special :: :break
 
   @spec to_plaintext(t()) :: String.t() | nil
@@ -39,6 +41,8 @@ defmodule ScreensConfig.FreeText do
   def to_plaintext(%{route: :green_c}), do: "Green Line - C branch"
   def to_plaintext(%{route: :green_d}), do: "Green Line - D branch"
   def to_plaintext(%{route: :green_e}), do: "Green Line - E branch"
+  def to_plaintext(%{route: :ferry}), do: "Ferry"
+  def to_plaintext(%{route: :capeflyer}), do: "CapeFlyer"
 
   def to_plaintext(%{format: _, text: text}), do: text
 

--- a/lib/config/free_text/free_text.ex
+++ b/lib/config/free_text/free_text.ex
@@ -23,8 +23,8 @@ defmodule ScreensConfig.FreeText do
           | :green_c
           | :green_d
           | :green_e
-          | :capeflyer
           | :ferry
+          | :capeflyer
   @type color :: :red | :blue | :orange | :green | :silver | :purple | :teal | :ocean_blue
   @type special :: :break
 


### PR DESCRIPTION
**Asana task**: [Fix incorrect route pill for Cape Flyer](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1210794505820587?focus=true)

Add CapeFlyer and it's associated color to the typespec for `route_pill` and `color` within `FreeText`
