### PR TITLE
feat: Emergency Takeover config for DUP, PreFares and Sectionals

### DIFF
--- a/lib/config/emergency_takeover.ex
+++ b/lib/config/emergency_takeover.ex
@@ -1,0 +1,17 @@
+defmodule ScreensConfig.EmergencyTakeover do
+  @moduledoc false
+
+  @type t :: %__MODULE__{
+          audio_asset_path: String.t() | nil,
+          text_for_audio: String.t() | nil,
+          visual_asset_path: String.t()
+        }
+
+  @enforce_keys ~w[visual_asset_path]a
+  defstruct [:audio_asset_path, :text_for_audio, visual_asset_path: ""]
+
+  use ScreensConfig.Struct
+
+  defp value_from_json(_, value), do: value
+  defp value_to_json(_, value), do: value
+end

--- a/lib/config/screen/busway.ex
+++ b/lib/config/screen/busway.ex
@@ -11,10 +11,17 @@ defmodule ScreensConfig.Screen.Busway do
   typically split into multiple sections.
   """
 
-  alias ScreensConfig.{Departures, EmergencyMessagingLocation, EvergreenContentItem, Header}
+  alias ScreensConfig.{
+    Departures,
+    EmergencyMessagingLocation,
+    EmergencyTakeover,
+    EvergreenContentItem,
+    Header
+  }
 
   @type t :: %__MODULE__{
           departures: Departures.t(),
+          emergency_takeover: EmergencyTakeover.t() | nil,
           emergency_messaging_location: EmergencyMessagingLocation.t(),
           evergreen_content: list(EvergreenContentItem.t()),
           header: Header.t(),
@@ -24,6 +31,7 @@ defmodule ScreensConfig.Screen.Busway do
   @enforce_keys [:departures, :header]
   defstruct departures: nil,
             emergency_messaging_location: nil,
+            emergency_takeover: nil,
             evergreen_content: [],
             header: nil,
             include_logo_in_header: false
@@ -31,7 +39,8 @@ defmodule ScreensConfig.Screen.Busway do
   use ScreensConfig.Struct,
     children: [
       departures: Departures,
-      evergreen_content: {:list, EvergreenContentItem}
+      evergreen_content: {:list, EvergreenContentItem},
+      emergency_takeover: EmergencyTakeover
     ]
 
   use Header

--- a/lib/config/screen/dup.ex
+++ b/lib/config/screen/dup.ex
@@ -5,6 +5,7 @@ defmodule ScreensConfig.Screen.Dup do
     Alerts,
     Departures,
     EmergencyMessagingLocation,
+    EmergencyTakeover,
     EvergreenContentItem,
     Header
   }
@@ -15,18 +16,21 @@ defmodule ScreensConfig.Screen.Dup do
           primary_departures: Departures.t(),
           secondary_departures: Departures.t(),
           alerts: Alerts.t(),
-          emergency_messaging_location: EmergencyMessagingLocation.t()
+          emergency_messaging_location: EmergencyMessagingLocation.t(),
+          emergency_takeover: EmergencyTakeover.t() | nil
         }
 
   @enforce_keys [:header, :primary_departures, :secondary_departures, :alerts]
-  defstruct @enforce_keys ++ [emergency_messaging_location: nil, evergreen_content: []]
+  defstruct @enforce_keys ++
+              [emergency_messaging_location: nil, evergreen_content: [], emergency_takeover: nil]
 
   use ScreensConfig.Struct,
     children: [
       primary_departures: Departures,
       secondary_departures: Departures,
       alerts: Alerts,
-      evergreen_content: {:list, EvergreenContentItem}
+      evergreen_content: {:list, EvergreenContentItem},
+      emergency_takeover: EmergencyTakeover
     ]
 
   use Header
@@ -34,5 +38,6 @@ defmodule ScreensConfig.Screen.Dup do
   defp value_from_json("emergency_messaging_location", value),
     do: EmergencyMessagingLocation.from_json(value)
 
+  defp value_from_json(_, value), do: value
   defp value_to_json(_, value), do: value
 end

--- a/lib/config/screen/pre_fare.ex
+++ b/lib/config/screen/pre_fare.ex
@@ -7,6 +7,7 @@ defmodule ScreensConfig.Screen.PreFare do
     Departures,
     ElevatorStatus,
     EmergencyMessagingLocation,
+    EmergencyTakeover,
     EvergreenContentItem,
     FullLineMap,
     Header
@@ -21,7 +22,8 @@ defmodule ScreensConfig.Screen.PreFare do
           evergreen_content: list(EvergreenContentItem.t()),
           content_summary: ContentSummary.t(),
           departures: Departures.t() | nil,
-          emergency_messaging_location: EmergencyMessagingLocation.t()
+          emergency_messaging_location: EmergencyMessagingLocation.t(),
+          emergency_takeover: EmergencyTakeover.t() | nil
         }
 
   @enforce_keys [
@@ -39,7 +41,8 @@ defmodule ScreensConfig.Screen.PreFare do
             evergreen_content: [],
             content_summary: nil,
             departures: nil,
-            emergency_messaging_location: nil
+            emergency_messaging_location: nil,
+            emergency_takeover: nil
 
   use ScreensConfig.Struct,
     children: [
@@ -48,7 +51,8 @@ defmodule ScreensConfig.Screen.PreFare do
       evergreen_content: {:list, EvergreenContentItem},
       reconstructed_alert_widget: Alerts,
       content_summary: ContentSummary,
-      departures: Departures
+      departures: Departures,
+      emergency_takeover: EmergencyTakeover
     ]
 
   use Header


### PR DESCRIPTION
Description
- Added new emergency_takeover field for screen configs and a module
- EmergencyTakeover has a required `visual_asset_path`
- Also has `text_for_audio` or an `audio_asset_path` to provide audio
  equivalence