### PR TITLE
feat: Wayfinding Dot Config

### DIFF
--- a/lib/config/departures/header.ex
+++ b/lib/config/departures/header.ex
@@ -7,12 +7,16 @@ defmodule ScreensConfig.Departures.Header do
   - `arrow` is the direction of a wayfinding arrow displayed alongside the title. This uses 8-way
     compass directions where "n" is towards the top of the display.
   - `image_path` is the path of an image displayed below the title (if present).
+  - `wayfinding_point` in combination with `image_path` allows for a breathing
+    blue location dot and an optional directional fan to be shown on the image.
+    `image_path` will need to be configured in order for `wayfinding_point` to display as well.
   - `subtitle` is an additional text element with less visual prominence, primarily intended for
     wayfinding directions.
   - `read_as` is how the section should be announced in audio readouts. If `nil`, defaults to the
     configured `title` plus `subtitle`. This applies even if the header has no visual components.
   """
 
+  alias __MODULE__.WayfindingPoint
   alias ScreensConfig.Arrow
 
   @type t :: %__MODULE__{
@@ -20,12 +24,13 @@ defmodule ScreensConfig.Departures.Header do
           image_path: String.t() | nil,
           read_as: String.t() | nil,
           subtitle: String.t() | nil,
-          title: String.t() | nil
+          title: String.t() | nil,
+          wayfinding_point: WayfindingPoint.t() | nil
         }
 
-  defstruct [:arrow, :image_path, :read_as, :subtitle, :title]
+  defstruct [:arrow, :image_path, :read_as, :subtitle, :title, :wayfinding_point]
 
-  use ScreensConfig.Struct, with_default: true
+  use ScreensConfig.Struct, children: [wayfinding_point: WayfindingPoint], with_default: true
 
   defp value_from_json("arrow", value), do: Arrow.from_json(value)
   defp value_from_json(_, value), do: value

--- a/lib/config/departures/header/wayfinding_point.ex
+++ b/lib/config/departures/header/wayfinding_point.ex
@@ -1,0 +1,25 @@
+defmodule ScreensConfig.Departures.Header.WayfindingPoint do
+  @moduledoc """
+  Configures a Wayfinding Dot on top of the Header Image.
+
+  - `x_position` is the x coordinate position in pixels from the left
+  - `y_position` is the y coordinate position in pixels from the top
+  - `beam_angle` is the angle in degrees we want to rotate
+    the directional beam from its starting position of up (0 degrees).
+    Can be negative degrees as well e.g. -45, -90
+  """
+
+  @type t :: %__MODULE__{
+          x_position: non_neg_integer(),
+          y_position: non_neg_integer(),
+          beam_angle: integer() | nil
+        }
+
+  @enforce_keys [:x_position, :y_position]
+  defstruct @enforce_keys ++ [:beam_angle]
+
+  use ScreensConfig.Struct
+
+  defp value_from_json(_, value), do: value
+  defp value_to_json(_, value), do: value
+end


### PR DESCRIPTION
Description
- Added `x_position`, `y_position` for allowing positioning of the Wayfinding dot
- Added `direction_beam_position` to allow for a directional beam to be placed either pointing up, down, left or right

Right now, the `direction_beam_position` values are being passed through and effectively re-serialized for use on the front end. I added this in for self documentation, but I'm good with omitting it if we want. 
