### PR TITLE
fix: missing struct for Sectional duo departures

### DIFF
--- a/lib/config/screen/busway.ex
+++ b/lib/config/screen/busway.ex
@@ -44,7 +44,8 @@ defmodule ScreensConfig.Screen.Busway do
     children: [
       departures: Departures,
       evergreen_content: {:list, EvergreenContentItem},
-      emergency_takeover: EmergencyTakeover
+      emergency_takeover: EmergencyTakeover,
+      secondary_departures: Departures
     ]
 
   use Header


### PR DESCRIPTION
This was missing in #91. Without it, secondary departures configuration was not properly decoded into a `Departures` struct when loaded into the app.