### PR TITLE
deps: upgrade to Elixir 1.20.2-otp-29

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17.3-otp-27
-erlang 27.3.4
+elixir 1.20.2-otp-29
+erlang 29.0.2

--- a/lib/config/screen.ex
+++ b/lib/config/screen.ex
@@ -75,7 +75,7 @@ defmodule ScreensConfig.Screen do
   end
 
   @spec schedule_refresh_at_time(t(), DateTime.t()) :: t()
-  def schedule_refresh_at_time(screen_config, time) do
+  def schedule_refresh_at_time(%__MODULE__{} = screen_config, time) do
     %__MODULE__{screen_config | refresh_if_loaded_before: time}
   end
 

--- a/lib/config/util.ex
+++ b/lib/config/util.ex
@@ -10,6 +10,7 @@ defmodule ScreensConfig.Util do
   def struct_keys(mod, opts \\ []) do
     keys =
       mod
+      |> struct()
       |> Map.from_struct()
       |> Map.keys()
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ScreensConfig.MixProject do
     [
       app: :screens_config,
       version: "0.1.0",
-      elixir: "~> 1.17",
+      elixir: "~> 1.20",
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -23,7 +23,7 @@ defmodule ScreensConfig.MixProject do
     [
       {:jason, "~> 1.0"},
       {:credo, "~> 1.7.6", only: [:dev, :test]},
-      {:dialyxir, "~> 1.4.3", only: [:dev, :test], runtime: false}
+      {:dialyxir, "~> 1.4.7", only: [:dev, :test], runtime: false}
     ]
   end
 end


### PR DESCRIPTION
**Asana task:** [Update screens-config-lib to Elixir 1.20 / OTP 29](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1215538526595331?focus=true)

- Upgrades to the newest stable versions of Elixir and Erlang
- Resolves associated dialyzer warnings