### PR TITLE
refactor: remove max_minutes option from Departure Filters

### DIFF
--- a/lib/config/departures/filters.ex
+++ b/lib/config/departures/filters.ex
@@ -2,18 +2,16 @@ defmodule ScreensConfig.Departures.Filters do
   @moduledoc """
   Configures filtering for the departures displayed in a `Section`.
 
-  - `max_minutes` limits how far in the future departures are allowed to be.
   - `route_directions` limits departures based on specific combinations of route and direction.
   """
 
   alias ScreensConfig.Departures.Filters.RouteDirections
 
   @type t :: %__MODULE__{
-          max_minutes: non_neg_integer() | nil,
           route_directions: RouteDirections.t() | nil
         }
 
-  defstruct max_minutes: nil, route_directions: nil
+  defstruct route_directions: nil
 
   use ScreensConfig.Struct, children: [route_directions: RouteDirections], with_default: true
 


### PR DESCRIPTION
**Asana task**: [Screens departures: remove unused time filter](https://app.asana.com/1/15492006741476/project/1185117109217413/task/1216571034745366?focus=true)

Description
This to be merged after https://github.com/mbta/screens/pull/3224 get's merged
